### PR TITLE
fix-public/shippingaddresse

### DIFF
--- a/app/controllers/public/shipping_addresses_controller.rb
+++ b/app/controllers/public/shipping_addresses_controller.rb
@@ -4,7 +4,7 @@ class Public::ShippingAddressesController < ApplicationController
 
   def index
     @shipping_address = ShippingAddress.new
-    @shipping_addresses = ShippingAddress.all
+    @shipping_addresses = ShippingAddress.where(customer_id: current_customer.id)
   end
 
   def create


### PR DESCRIPTION
#配送先一覧で起きていたバグの解消
-全ての会員の配送先を取得していたので、ログインしている会員の配送先のみを取得するように変更しました。